### PR TITLE
Fix new SSH key creation on Packet

### DIFF
--- a/lib/kontena/machine/packet/master_provisioner.rb
+++ b/lib/kontena/machine/packet/master_provisioner.rb
@@ -34,7 +34,7 @@ module Kontena
           end
 
           if respond_to?(:certificate_public_key) && !opts[:ssl_cert]
-            ssl_cert_public = = certificate_public_key(ssl_cert)
+            ssl_cert_public = certificate_public_key(ssl_cert)
           end
 
           name = generate_name

--- a/lib/kontena/machine/packet/master_provisioner.rb
+++ b/lib/kontena/machine/packet/master_provisioner.rb
@@ -33,6 +33,10 @@ module Kontena
             end
           end
 
+          if respond_to?(:certificate_public_key) && !opts[:ssl_cert]
+            ssl_cert_public = = certificate_public_key(ssl_cert)
+          end
+
           name = generate_name
 
           userdata_vars = opts.merge(
@@ -84,6 +88,7 @@ module Kontena
             public_ip: public_ip['address'],
             code: opts[:initial_admin_code],
             provider: 'packet',
+            ssl_certificate: ssl_cert_public,
             version: master_version
           }
         end

--- a/lib/kontena/machine/packet/packet_common.rb
+++ b/lib/kontena/machine/packet/packet_common.rb
@@ -10,7 +10,7 @@ module Kontena
         end
 
         def create_ssh_key(ssh_key)
-          client.create_ssh_key(ssh_key_label(ssh_key))
+          client.create_ssh_key(label: ssh_key_label(ssh_key), key: ssh_key)
         end
 
         def ssh_key_exist?(ssh_key)


### PR DESCRIPTION
Also adds the public key of generated self signed ssl certificate to response so it can be automatically installed during deploy.

Fixes https://github.com/kontena/kontena/issues/1353
