### PR TITLE
Change gem description to look like other plugins

### DIFF
--- a/kontena-plugin-packet.gemspec
+++ b/kontena-plugin-packet.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["info@kontena.io"]
 
   spec.summary       = "Kontena Packet plugin"
-  spec.description   = "Packet provision plugin for Kontena"
+  spec.description   = "Kontena Packet plugin"
   spec.homepage      = "https://github.com/kontena/kontena-plugin-packet"
   spec.license       = "Apache-2.0"
 


### PR DESCRIPTION
From: 

```
$ kontena plugin search
search
NAME                                               VERSION    DESCRIPTION
vagrant                                            0.2.5      Kontena Vagrant plugin
packet                                             0.2.5      Packet provision plugin for Kontena
digitalocean                                       0.2.5      Kontena DigitalOcean plugin
azure                                              0.2.5      Kontena Microsoft Azure plugin
aws                                                0.2.4      Kontena Amazon Web Services plugin
upcloud                                            0.2.5      Kontena Upcloud plugin
```

To:

```
$ kontena plugin search
search
NAME                                               VERSION    DESCRIPTION
vagrant                                            0.2.5      Kontena Vagrant plugin
packet                                             0.2.5      Kontena Packet plugin
digitalocean                                       0.2.5      Kontena DigitalOcean plugin
azure                                              0.2.5      Kontena Microsoft Azure plugin
aws                                                0.2.4      Kontena Amazon Web Services plugin
upcloud                                            0.2.5      Kontena Upcloud plugin
```

