### PR TITLE
Fix public ip address retrieval

### DIFF
--- a/lib/kontena/machine/packet/master_provisioner.rb
+++ b/lib/kontena/machine/packet/master_provisioner.rb
@@ -66,7 +66,9 @@ module Kontena
             end
           end
 
-          public_ip = device_public_ip(device)
+          public_ip = spinner "Looking for device public IP" do
+            device_public_ip(device)
+          end
           master_url = "https://#{public_ip['address']}"
 
           Excon.defaults[:ssl_verify_peer] = false


### PR DESCRIPTION
Fixes #25

Perhaps packet changed something and devices get IP addresses later than before, but the old implementation did not receive the device public IP any more.

Now it refreshes the device data and retries several times.

Before:
![image](https://user-images.githubusercontent.com/224971/26925810-e1350d26-4c53-11e7-878d-ef3fc7ba8eaf.png)

After:
![image](https://user-images.githubusercontent.com/224971/26925792-ce9874dc-4c53-11e7-9657-bbb18c90c9b6.png)
