### PR TITLE
Do not echo when prompting for token

### DIFF
--- a/lib/kontena/plugin/packet/token_option.rb
+++ b/lib/kontena/plugin/packet/token_option.rb
@@ -4,7 +4,7 @@ module Kontena::Plugin::Packet
       base.option "--token", "TOKEN", "Packet API token", environment_variable: 'PACKET_TOKEN'
       base.class_eval do
         def default_token
-          Kontena.prompt.ask("Packet API token:")
+          Kontena.prompt.ask("Packet API token:", echo: false)
         end
       end
     end


### PR DESCRIPTION
The token prompt should not echo the token.
