### PR TITLE
Allow copy-pasting of ssh key if none exist

### DIFF
--- a/lib/kontena/machine/packet/master_provisioner.rb
+++ b/lib/kontena/machine/packet/master_provisioner.rb
@@ -22,7 +22,7 @@ module Kontena
           abort('Operating system coreos_stable does not exist in Packet') unless os = find_os('coreos_stable')
           abort('Device type does not exist in Packet') unless plan = find_plan(opts[:plan])
 
-          check_or_create_ssh_key(File.expand_path(opts[:ssh_key])) if opts[:ssh_key]
+          check_or_create_ssh_key(opts[:ssh_key]) if opts[:ssh_key]
 
           if opts[:ssl_cert]
             abort('Invalid ssl cert') unless File.exists?(File.expand_path(opts[:ssl_cert]))

--- a/lib/kontena/machine/packet/packet_common.rb
+++ b/lib/kontena/machine/packet/packet_common.rb
@@ -22,11 +22,9 @@ module Kontena
           label.empty? ? "kontena-ssh-key-#{rand(1..9)}" : label
         end
 
-        # @param [String] keyfile_path Path to ssh keyfile
-        def check_or_create_ssh_key(keyfile_path)
-          abort('Ssh key file not found') unless File.exist?(keyfile_path)
-          abort('Ssh key file not readable') unless File.readable?(keyfile_path)
-          ssh_key = File.read(keyfile_path).strip
+        # @param [String] ssh_key SSH public key
+        def check_or_create_ssh_key(ssh_key)
+          return nil if ssh_key.nil?
           create_ssh_key(ssh_key) unless ssh_key_exist?(ssh_key)
         end
 

--- a/lib/kontena/plugin/packet.rb
+++ b/lib/kontena/plugin/packet.rb
@@ -1,7 +1,7 @@
 module Kontena
   module Plugin
     module Packet
-      VERSION = "0.2.7.rc1"
+      VERSION = "0.2.6"
     end
   end
 end

--- a/lib/kontena/plugin/packet.rb
+++ b/lib/kontena/plugin/packet.rb
@@ -1,7 +1,7 @@
 module Kontena
   module Plugin
     module Packet
-      VERSION = "0.2.6"
+      VERSION = "0.2.7.rc1"
     end
   end
 end

--- a/lib/kontena/plugin/packet/master/create_command.rb
+++ b/lib/kontena/plugin/packet/master/create_command.rb
@@ -2,6 +2,7 @@ require 'kontena/plugin/packet/token_option'
 require 'kontena/plugin/packet/project_option'
 require 'kontena/plugin/packet/type_option'
 require 'kontena/plugin/packet/facility_option'
+require 'kontena/plugin/packet/ssh_key_option'
 
 module Kontena::Plugin::Packet::Master
   class CreateCommand < Kontena::Command
@@ -10,11 +11,11 @@ module Kontena::Plugin::Packet::Master
     include Kontena::Plugin::Packet::ProjectOption
     include Kontena::Plugin::Packet::TypeOption
     include Kontena::Plugin::Packet::FacilityOption
+    include Kontena::Plugin::Packet::SshKeyOption
 
     option "--name", "[NAME]", "Set master name"
     option "--ssl-cert", "PATH", "SSL certificate file (optional)"
     option "--billing", "BILLING", "Billing cycle", default: 'hourly'
-    option "--ssh-key", "PATH", "Path to ssh public key", default: File.join(Dir.home, '.ssh', 'id_rsa.pub')
     option "--vault-secret", "VAULT_SECRET", "Secret key for Vault (optional)"
     option "--vault-iv", "VAULT_IV", "Initialization vector for Vault (optional)"
     option "--mongodb-uri", "URI", "External MongoDB uri (optional)"

--- a/lib/kontena/plugin/packet/nodes/create_command.rb
+++ b/lib/kontena/plugin/packet/nodes/create_command.rb
@@ -2,6 +2,7 @@ require 'kontena/plugin/packet/token_option'
 require 'kontena/plugin/packet/project_option'
 require 'kontena/plugin/packet/type_option'
 require 'kontena/plugin/packet/facility_option'
+require 'kontena/plugin/packet/ssh_key_option'
 
 module Kontena::Plugin::Packet::Nodes
   class CreateCommand < Kontena::Command
@@ -11,11 +12,11 @@ module Kontena::Plugin::Packet::Nodes
     include Kontena::Plugin::Packet::ProjectOption
     include Kontena::Plugin::Packet::TypeOption
     include Kontena::Plugin::Packet::FacilityOption
+    include Kontena::Plugin::Packet::SshKeyOption
 
     parameter "[NAME]", "Node name"
 
     option "--billing", "BILLING", "Billing cycle", default: 'hourly'
-    option "--ssh-key", "PATH", "Path to ssh public key", default: File.join(Dir.home, '.ssh', 'id_rsa.pub')
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
 
     def execute

--- a/lib/kontena/plugin/packet/ssh_key_option.rb
+++ b/lib/kontena/plugin/packet/ssh_key_option.rb
@@ -1,0 +1,36 @@
+module Kontena::Plugin::Packet
+  module SshKeyOption
+
+    DEFAULT_PATH = File.join(Dir.home, '.ssh', 'id_rsa.pub')
+
+    def self.included(base)
+      base.option "--ssh-key", "PATH", "Path to ssh public key", attribute_name: :ssh_key_path, default: DEFAULT_PATH
+      base.class_eval do
+        def ssh_key
+          if ssh_key_path
+            begin
+              return File.read(ssh_key_path).strip
+            rescue => ex
+              unless ssh_key_path == DEFAULT_PATH
+                raise ex
+              end
+            end
+          end
+
+          require 'packet'
+          client = Packet::Client.new(self.token || (self.respond_to?(:default_token) && self.default_token))
+
+          keys = client.list_ssh_keys
+
+          if keys.empty?
+            prompt.ask('SSH public key: (enter an ssh key in OpenSSH format "ssh-xxx xxxxx key_name")') do |q|
+              q.validate /^ssh-rsa \S+ \S+$/
+            end
+          else
+            keys.first.key
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/kontena/plugin/packet/master/create_command_spec.rb
+++ b/spec/kontena/plugin/packet/master/create_command_spec.rb
@@ -22,6 +22,7 @@ describe Kontena::Plugin::Packet::Master::CreateCommand do
       account: :master
     )
     subject.config.current_server='foo'
+    allow(subject).to receive(:ssh_key).and_return("abcd")
   end
 
   describe '#run' do

--- a/spec/kontena/plugin/packet/nodes/create_command_spec.rb
+++ b/spec/kontena/plugin/packet/nodes/create_command_spec.rb
@@ -23,6 +23,7 @@ describe Kontena::Plugin::Packet::Nodes::CreateCommand do
       allow(subject).to receive(:require_token).and_return('12345')
       allow(subject).to receive(:fetch_grid).and_return({})
       allow(subject).to receive(:client).and_return(client)
+      allow(subject).to receive(:ssh_key).and_return("abcd")
     end
 
     it 'passes options to provisioner' do


### PR DESCRIPTION
Fixes #30

Adds a prompt where you can copy-paste a ssh public key to be uploaded to Packet if none exist

Installable through `kontena plugin install --pre packet`
