### PR TITLE
Obey node and master names supplied at creation time (issue #19)

### DIFF
--- a/lib/kontena/machine/packet/master_provisioner.rb
+++ b/lib/kontena/machine/packet/master_provisioner.rb
@@ -37,11 +37,7 @@ module Kontena
             ssl_cert_public = certificate_public_key(ssl_cert)
           end
 
-          if !opts[:name]
-            name = generate_name
-          else
-            name = opts[:name]
-          end
+          name = opts[:name] || generate_name
 
           userdata_vars = opts.merge(
             ssl_cert: ssl_cert,

--- a/lib/kontena/machine/packet/master_provisioner.rb
+++ b/lib/kontena/machine/packet/master_provisioner.rb
@@ -37,7 +37,11 @@ module Kontena
             ssl_cert_public = certificate_public_key(ssl_cert)
           end
 
-          name = generate_name
+          if !opts[:name]
+            name = generate_name
+          else
+            name = opts[:name]
+          end
 
           userdata_vars = opts.merge(
             ssl_cert: ssl_cert,

--- a/lib/kontena/machine/packet/node_provisioner.rb
+++ b/lib/kontena/machine/packet/node_provisioner.rb
@@ -29,8 +29,14 @@ module Kontena
             grid_token: opts[:grid_token],
           }
 
+          if !opts[:name]
+            name = generate_name
+          else
+            name = opts[:name]
+          end
+
           device = project.new_device(
-            hostname: generate_name,
+            hostname: name,
             facility: facility.to_hash,
             operating_system: os.to_hash,
             plan: plan.to_hash,

--- a/lib/kontena/machine/packet/node_provisioner.rb
+++ b/lib/kontena/machine/packet/node_provisioner.rb
@@ -29,11 +29,7 @@ module Kontena
             grid_token: opts[:grid_token],
           }
 
-          if !opts[:name]
-            name = generate_name
-          else
-            name = opts[:name]
-          end
+          name = opts[:name] || generate_name
 
           device = project.new_device(
             hostname: name,

--- a/lib/kontena/plugin/packet/master/create_command.rb
+++ b/lib/kontena/plugin/packet/master/create_command.rb
@@ -37,7 +37,8 @@ module Kontena::Plugin::Packet::Master
           vault_secret: vault_secret || SecureRandom.hex(24),
           vault_iv: vault_iv || SecureRandom.hex(24),
           initial_admin_code: SecureRandom.hex(16),
-          mongodb_uri: mongodb_uri
+          mongodb_uri: mongodb_uri,
+          name: name
       )
     end
 

--- a/lib/kontena/plugin/packet/nodes/create_command.rb
+++ b/lib/kontena/plugin/packet/nodes/create_command.rb
@@ -34,7 +34,8 @@ module Kontena::Plugin::Packet::Nodes
         ssh_key: ssh_key,
         plan: plan,
         facility: facility,
-        version: version
+        version: version,
+        name: name
       )
     end
 


### PR DESCRIPTION
Currently the plugin ignores names supplied for the master and node when creating machines and just autogenerates its own names. This patch fixes that to use the name supplied by the user if it exists, otherwise it falls back to autogenerating a name as before.